### PR TITLE
fix: NoneType value in serialized tree

### DIFF
--- a/django_auto_serializer/auto_serializer.py
+++ b/django_auto_serializer/auto_serializer.py
@@ -92,17 +92,18 @@ class SerializableInstance(BaseSerializableInstance):
         """
 
         """
+        value = ofield.value_from_object(obj)
         # everything to string for the first time
-        value = ofield.value_to_string(obj)
+
 
         # better specification for numeric types
-        if type(ofield) in (BooleanField,
-                            NullBooleanField,
-                            IntegerField,
-                            FloatField,
-                            PositiveIntegerField,
-                            ForeignKey):
-            value = ofield.value_from_object(obj)
+        if type(ofield) not in (BooleanField,
+                                NullBooleanField,
+                                IntegerField,
+                                FloatField,
+                                PositiveIntegerField,
+                                ForeignKey) and value != None:
+            value = ofield.value_to_string(obj)
         # specify others types here if needed
         #
 


### PR DESCRIPTION
None values was serialized as 'None' (str) in tree dict